### PR TITLE
feat: sync daemon orchestration (Phase 12)

### DIFF
--- a/nstd/daemon.py
+++ b/nstd/daemon.py
@@ -148,7 +148,7 @@ def run_task_sync(conn: sqlite3.Connection, config: NstdConfig) -> dict:
         Dict with keys: total_fetched (int), total_updated (int),
                         errors (list[str]), log_id (int)
     """
-    log_id = start_sync_log(conn, source="all")
+    log_id = start_sync_log(conn, source=None)
     total_fetched = 0
     total_updated = 0
     errors = []
@@ -165,14 +165,17 @@ def run_task_sync(conn: sqlite3.Connection, config: NstdConfig) -> dict:
             stats = sync_fn(conn, config)
             total_fetched += stats.get("fetched", 0)
             total_updated += stats.get("updated", 0)
+            # Aggregate per-source errors from stats dict
+            for err in stats.get("errors", []):
+                errors.append(f"{source_name}: {err}")
             logger.info(
                 "Synced %d/%d tasks from %s",
                 stats.get("updated", 0),
                 stats.get("fetched", 0),
                 source_name,
             )
-        except Exception:
-            error_msg = f"{source_name} sync failed"
+        except Exception as exc:
+            error_msg = f"{source_name} sync failed: {exc}"
             errors.append(error_msg)
             logger.exception(error_msg)
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -82,6 +82,7 @@ class TestRunTaskSync:
 
         assert len(result["errors"]) >= 1
         assert "GitHub" in result["errors"][0]
+        assert "GitHub API rate limited" in result["errors"][0]
 
     @patch("nstd.daemon._sync_asana")
     @patch("nstd.daemon._sync_jira")
@@ -127,6 +128,37 @@ class TestRunTaskSync:
         log = conn.execute("SELECT * FROM sync_log ORDER BY id DESC LIMIT 1").fetchone()
         assert log is not None
         assert log["status"] == "success"
+
+    @patch("nstd.daemon._sync_asana")
+    @patch("nstd.daemon._sync_jira")
+    @patch("nstd.daemon._sync_github")
+    def test_sync_log_source_is_null_for_full_sync(self, mock_gh, mock_jira, mock_asana, conn):
+        """Full sync should log source=NULL per spec (NULL = full sync)."""
+        mock_gh.return_value = {"fetched": 1, "updated": 1}
+        mock_jira.return_value = {"fetched": 0, "updated": 0, "errors": []}
+        mock_asana.return_value = {"fetched": 0, "updated": 0, "errors": []}
+
+        config = MagicMock()
+        run_task_sync(conn, config)
+
+        log = conn.execute("SELECT * FROM sync_log ORDER BY id DESC LIMIT 1").fetchone()
+        assert log["source"] is None
+
+    @patch("nstd.daemon._sync_asana")
+    @patch("nstd.daemon._sync_jira")
+    @patch("nstd.daemon._sync_github")
+    def test_aggregates_per_source_errors(self, mock_gh, mock_jira, mock_asana, conn):
+        """Per-source errors from stats dicts should be aggregated."""
+        mock_gh.return_value = {"fetched": 5, "updated": 3, "errors": ["rate limited on repo X"]}
+        mock_jira.return_value = {"fetched": 2, "updated": 2, "errors": []}
+        mock_asana.return_value = {"fetched": 1, "updated": 0, "errors": ["project not found"]}
+
+        config = MagicMock()
+        result = run_task_sync(conn, config)
+
+        assert len(result["errors"]) == 2
+        assert "GitHub: rate limited on repo X" in result["errors"][0]
+        assert "Asana: project not found" in result["errors"][1]
 
     @patch("nstd.daemon._sync_asana")
     @patch("nstd.daemon._sync_jira")


### PR DESCRIPTION
## Phase 12: Sync Daemon (§6.1, §15, §16)

Implements the sync daemon orchestration layer.

### What it does

**Task sync (`run_task_sync()`)**
- Calls GitHub, Jira, and Asana sync functions in sequence
- Error isolation: failure in one source does not abort others (§15)
- Upserts all successfully fetched tasks into the database
- Creates sync log entry with success/error status

**Calendar poll (`run_calendar_poll()`)**
- Orchestrates the calendar poll cycle via `poll_calendars()`
- Graceful error handling — poll failure logged, not crashed

**Log sanitization (`LogSanitizer`)**
- Logging filter per §16: API tokens never appear in log output
- Redacts: GitHub PATs (`ghp_`, `gho_`, `github_pat_`), Bearer tokens, `token=`, `api_key=`, `password=`, `secret=` patterns

### Testing

16 new tests:
- Task sync calls all three sources ✅
- GitHub error doesn't abort Jira/Asana ✅
- All sources fail → all errors recorded ✅
- Sync log entries created ✅
- Fetched tasks upserted into DB ✅
- Calendar poll orchestration ✅
- Calendar poll error handling ✅
- Log sanitizer strips 4 token pattern types ✅
- Non-sensitive messages preserved ✅

**Full suite: 115 tests, 97.84% coverage**

### Files
- `nstd/daemon.py` (new)
- `tests/unit/test_daemon.py` (new)