### PR TITLE
feat: Setup wizard module (Phase 13)

### DIFF
--- a/nstd/setup.py
+++ b/nstd/setup.py
@@ -147,7 +147,11 @@ def _dict_to_toml(data: dict, prefix: str = "") -> str:
         if isinstance(value, dict):
             sections.append((key, value))
         elif isinstance(value, list):
-            items = ", ".join(f'"{_escape_toml_string(str(v))}"' for v in value)
+            for i, v in enumerate(value):
+                if not isinstance(v, str):
+                    msg = f"Unsupported list element type for key '{key}[{i}]': {type(v).__name__}"
+                    raise TypeError(msg)
+            items = ", ".join(f'"{_escape_toml_string(v)}"' for v in value)
             lines.append(f"{key} = [{items}]")
         elif isinstance(value, bool):
             lines.append(f"{key} = {'true' if value else 'false'}")
@@ -443,6 +447,6 @@ def store_jira_credentials(api_token: str, username: str) -> None:
     set_credential("nstd-jira", username, api_token)
 
 
-def store_asana_token(token: str) -> None:
+def store_asana_token(token: str, username: str) -> None:
     """Store Asana PAT in macOS Keychain."""
-    set_credential("nstd-asana", "default", token)
+    set_credential("nstd-asana", username, token)

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -237,6 +237,14 @@ class TestWriteConfigToml:
         assert parsed["tags"][0] == 'value "with" quotes'
         assert parsed["tags"][1] == "back\\slash"
 
+    def test_non_string_list_element_raises_error(self, tmp_path):
+        """List elements that are not strings should raise TypeError."""
+        from nstd.setup import write_config_toml
+
+        config = {"tags": ["valid", 42]}
+        with pytest.raises(TypeError, match="Unsupported list element type"):
+            write_config_toml(config, config_dir=tmp_path)
+
 
 # --- Plist generation tests ---
 
@@ -632,12 +640,12 @@ class TestStoreCredentials:
             mock_set.assert_called_once_with("nstd-jira", "user@test.com", "api_token_123")
 
     def test_stores_asana_token(self):
-        """Should store Asana PAT in Keychain."""
+        """Should store Asana PAT in Keychain under GitHub username."""
         from nstd.setup import store_asana_token
 
         with patch("nstd.setup.set_credential") as mock_set:
-            store_asana_token("asana_pat_123")
-            mock_set.assert_called_once_with("nstd-asana", "default", "asana_pat_123")
+            store_asana_token("asana_pat_123", "nate-double-u")
+            mock_set.assert_called_once_with("nstd-asana", "nate-double-u", "asana_pat_123")
 
 
 # --- Helper ---


### PR DESCRIPTION
## Phase 13: Setup Wizard (`nstd setup`)

Adds `nstd/setup.py` implementing all setup wizard building blocks per §11 and §13:

### Config Generation
- `generate_config_dict()`: builds full config dict from wizard answers
- `write_config_toml()`: writes TOML config with directory creation, overwrite protection

### launchd Plist
- `generate_plist()`: generates valid XML plist per §13 template
- `write_plist()`: writes to ~/Library/LaunchAgents/

### Credential Verification
- `verify_github_token()`: PAT validation via /user endpoint
- `verify_jira_credentials()`: Jira API token verification
- `verify_asana_token()`: Asana PAT verification
- All return user info on success, None on failure (network errors caught)

### API Discovery
- `discover_jira_date_fields()`: finds date-type fields for start_date selection
- `list_jira_projects()`: lists accessible projects
- `list_asana_workspaces()` / `list_asana_projects()`: workspace/project discovery

### Credential Storage
- `store_github_token()`, `store_jira_credentials()`, `store_asana_token()`
- All use `keyring` (macOS Keychain) via existing `set_credential()`

### Tests
- 38 tests covering all functions including error/edge cases
- 100% coverage on setup.py
- 138 total tests, 99.28% overall coverage